### PR TITLE
Improve transfer throughput and progress reporting

### DIFF
--- a/DirectPackageInstaller/DirectPackageInstaller.Desktop/Program.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller.Desktop/Program.cs
@@ -65,6 +65,7 @@ namespace DirectPackageInstaller.Desktop
             Console.WriteLine($"DirectPacakgeInstaller v{SelfUpdate.CurrentVersion} - CLI");
 
             bool Proxy = false;
+            bool ShowProgress = false;
             string Server = null;
             string PSIP = null;
             string URL = null;
@@ -105,6 +106,9 @@ namespace DirectPackageInstaller.Desktop
                     case "proxy":
                         Proxy = true;
                         break;
+                    case "progress":
+                        ShowProgress = true;
+                        break;
                     case "help":
                     case "h":
                     case "?":
@@ -116,7 +120,7 @@ namespace DirectPackageInstaller.Desktop
                         Console.ForegroundColor = ConsoleColor.Yellow;
                         Console.WriteLine("Syntax:");
                         Console.ResetColor();
-                        Console.WriteLine("  DirectPackageInstaller.Desktop -Server PKG_SENDER_PC_IP -PS4 PS4_IP -Port BIN_LOADER_PORT -DPIPort PKG_INFO_PORT [-Proxy] URL");
+                        Console.WriteLine("  DirectPackageInstaller.Desktop -Server PKG_SENDER_PC_IP -PS4 PS4_IP -Port BIN_LOADER_PORT -DPIPort PKG_INFO_PORT [-Proxy] [-Progress] URL");
                         Console.WriteLine();
 
                         Console.ForegroundColor = ConsoleColor.Yellow;
@@ -157,6 +161,12 @@ namespace DirectPackageInstaller.Desktop
                         Console.WriteLine("  -Proxy (optional)");
                         Console.ResetColor();
                         Console.WriteLine("    Makes the PS4 download the PKG via DirectPackageInstaller as a proxy.");
+                        Console.WriteLine();
+
+                        Console.ForegroundColor = ConsoleColor.Cyan;
+                        Console.WriteLine("  -Progress (optional)");
+                        Console.ResetColor();
+                        Console.WriteLine("    Shows how much data the PS4 is reading from DirectPackageInstaller.");
                         Console.WriteLine();
 
                         Console.ForegroundColor = ConsoleColor.Cyan;
@@ -246,6 +256,26 @@ namespace DirectPackageInstaller.Desktop
                 Console.WriteLine($"Port: {Port}");
 
             PS4Server PSServer = new PS4Server(Server);
+            DateTime LastProgressUpdate = DateTime.MinValue;
+            if (ShowProgress)
+            {
+                PSServer.TransferProgressChanged += Info =>
+                {
+                    var Now = DateTime.Now;
+                    if (!Info.Completed && (Now - LastProgressUpdate).TotalMilliseconds < 500)
+                        return;
+
+                    LastProgressUpdate = Now;
+                    var Sent = TransferProgressInfo.FormatBytes(Info.BytesSent);
+                    var Total = TransferProgressInfo.FormatBytes(Info.TotalBytes);
+                    var Speed = TransferProgressInfo.FormatBytes(Info.BytesPerSecond);
+
+                    if (Info.Completed)
+                        Console.WriteLine($"\rSent {Sent} / {Total}                    ");
+                    else
+                        Console.Write($"\rSending {Sent} / {Total} ({Info.Percent:P1}) - {Speed}/s        ");
+                };
+            }
             
             try
             {
@@ -296,7 +326,7 @@ namespace DirectPackageInstaller.Desktop
                     {
                         Proxy = true;
                         PKG = new FileStream(DirectURL, FileMode.Open);
-                        URL = $"http://{Server}:{PSServer.Server.Settings.Port}/file/?b64={Convert.ToBase64String(Encoding.UTF8.GetBytes(URL))}";
+                        URL = $"http://{Server}:{PSServer.Port}/file/?b64={Convert.ToBase64String(Encoding.UTF8.GetBytes(URL))}";
                     }
                     else
                     {
@@ -308,7 +338,7 @@ namespace DirectPackageInstaller.Desktop
                         if ((!HostStream.DirectLink || Proxy) && !HostStream.SingleConnection)
                         {
                             Proxy = true;
-                            URL = $"http://{Server}:{PSServer.Server.Settings.Port}/proxy/?b64={Convert.ToBase64String(Encoding.UTF8.GetBytes(URL))}";
+                            URL = $"http://{Server}:{PSServer.Port}/proxy/?b64={Convert.ToBase64String(Encoding.UTF8.GetBytes(URL))}";
                         }
 
                         if (HostStream.SingleConnection)
@@ -346,7 +376,7 @@ namespace DirectPackageInstaller.Desktop
                         while (DownTask?.SafeReadyLength < Info?.PreloadLength)
                             Task.Delay(1000).ConfigureAwait(false).GetAwaiter().GetResult();
 
-                        URL = $"http://{Server}:{PSServer.Server.Settings.Port}/cache/?b64={Convert.ToBase64String(Encoding.UTF8.GetBytes(URL))}";
+                        URL = $"http://{Server}:{PSServer.Port}/cache/?b64={Convert.ToBase64String(Encoding.UTF8.GetBytes(URL))}";
                     }
                     else
                     {

--- a/DirectPackageInstaller/DirectPackageInstaller/App.axaml.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/App.axaml.cs
@@ -147,6 +147,7 @@ namespace DirectPackageInstaller
                 IniWriter.SetValue("EnableCNL", Config.EnableCNL.ToString());
                 IniWriter.SetValue("Concurrency", SegmentedStream.DefaultConcurrency.ToString());
                 IniWriter.SetValue("ShowError", Config.ShowError.ToString());
+                IniWriter.SetValue("ShowTransferProgress", Config.ShowTransferProgress.ToString());
                 IniWriter.SetValue("SkipUpdateCheck", Config.SkipUpdateCheck.ToString());
                 IniWriter.SetValue("EthernetAdapter", Config.EthernetAdapter);
                 IniWriter.SetValue("EnableDHCP", Config.EnableDHCP.ToString());

--- a/DirectPackageInstaller/DirectPackageInstaller/Compression/Common.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Compression/Common.cs
@@ -104,7 +104,7 @@ namespace DirectPackageInstaller.Compression
                     if (Buffer == null) {
                         Buffer = () =>
                         {
-                            var Stream = new FileStream(TempFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite, 1024 * 1024 * 2, FileOptions.RandomAccess | FileOptions.WriteThrough);
+                            var Stream = new FileStream(TempFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite, TransferTuning.DiskBufferSize, TransferTuning.TempFileOptions);
                             Args.This.Instances.Add(Stream);
                             return Stream;
                         };

--- a/DirectPackageInstaller/DirectPackageInstaller/Compression/SharpComp.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Compression/SharpComp.cs
@@ -54,7 +54,7 @@ namespace DirectPackageInstaller.Compression
                 if (File.Exists(TmpFile))
                     File.Delete(TmpFile);
                 
-                using Stream Output = File.Open(TmpFile, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite);
+                using Stream Output = new FileStream(TmpFile, FileMode.CreateNew, FileAccess.Write, FileShare.ReadWrite, TransferTuning.DiskBufferSize, TransferTuning.TempFileOptions);
 
                 long TDecomp = 0;
                 var InTrans = false;
@@ -62,7 +62,7 @@ namespace DirectPackageInstaller.Compression
                 var TaskInfo = new DecompressTaskInfo() {
                     EntryName = EntryName,
                     TotalSize = Entry.Size,
-                    Content = () => File.Open(TmpFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite),
+                    Content = () => new FileStream(TmpFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, TransferTuning.DiskBufferSize, TransferTuning.TempFileOptions),
                     Running = true,
                     TotalDecompressed = &TDecomp,
                     InSegmentTranstion = &InTrans,
@@ -89,7 +89,7 @@ namespace DirectPackageInstaller.Compression
                 try
                 {
                     int ReadTries = 0;
-                    var Buffer = new byte[1024 * 1024 * 1];
+                    var Buffer = new byte[TransferTuning.HttpServerBufferSize];
 
                     int Readed;
                     do

--- a/DirectPackageInstaller/DirectPackageInstaller/Host/DecompressService.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Host/DecompressService.cs
@@ -251,27 +251,15 @@ namespace DirectPackageInstaller.Host
             if (!Range.HasValue)
                 return 0;
 
-            if (Range.Value.Begin < 0)
-                return 0;
-
-            if (Range.Value.Begin > TotalLength)
-                return TotalLength;
-
-            return Range.Value.Begin;
+            return Range.Value.GetStart(TotalLength);
         }
 
         private static long GetRangeLength(HttpRange? Range, long TotalLength)
         {
-            long Start = GetRangeStart(Range, TotalLength);
-            long End = Range?.End ?? TotalLength - 1;
+            if (!Range.HasValue)
+                return TotalLength;
 
-            if (End >= TotalLength)
-                End = TotalLength - 1;
-
-            if (End < Start)
-                return 0;
-
-            return End - Start + 1;
+            return Range.Value.GetLength(TotalLength);
         }
     }
 }

--- a/DirectPackageInstaller/DirectPackageInstaller/Host/DecompressService.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Host/DecompressService.cs
@@ -1,8 +1,10 @@
 ﻿using DirectPackageInstaller.Compression;
 using HttpServerLite;
+using DirectPackageInstaller.IO;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -11,6 +13,8 @@ namespace DirectPackageInstaller.Host
     public class DecompressService
     {
         const long MaxSkipBufferSize = 1024 * 1024 * 100;
+
+        public Action<TransferProgressInfo>? ProgressReporter { get; set; }
 
         private readonly Dictionary<string, int> Instances = new Dictionary<string, int>();
 
@@ -142,24 +146,96 @@ namespace DirectPackageInstaller.Host
             try
             {
                 Context.Response.Headers["Connection"] = "Keep-Alive";
-                Context.Response.Headers["Accept-Ranges"] = "none";
+                Context.Response.Headers["Accept-Ranges"] = "bytes";
                 Context.Response.Headers["Content-Type"] = "application/octet-stream";
+                Context.Request.Keepalive = true;
+
+                long transferStart = 0;
+                long responseLength = TaskInfo.TotalSize;
 
                 if (Partial)
                 {
-                    Context.Response.ContentLength = Range?.Length ?? TaskInfo.TotalSize - Range?.Begin ?? TaskInfo.TotalSize;
-                    Context.Response.Headers["Content-Range"] = $"bytes {Range?.Begin ?? 0}-{Range?.End ?? TaskInfo.TotalSize}/{TaskInfo.TotalSize}";
+                    long rangeStart = GetRangeStart(Range, TaskInfo.TotalSize);
+                    long rangeLength = GetRangeLength(Range, TaskInfo.TotalSize);
+                    long rangeEnd = rangeStart + rangeLength - 1;
 
-                    RespData = new VirtualStream(RespData, Range?.Begin ?? 0, Context.Response.ContentLength.Value);
+                    if (rangeLength == 0)
+                    {
+                        Context.Response.StatusCode = 416;
+                        Context.Response.StatusDescription = "Range Not Satisfiable";
+                        Context.Response.Headers["Content-Range"] = $"bytes */{TaskInfo.TotalSize}";
+                        Context.Response.Send(true);
+                        return;
+                    }
+
+                    Context.Response.ContentLength = rangeLength;
+                    Context.Response.Headers["Content-Range"] = $"bytes {rangeStart}-{rangeEnd}/{TaskInfo.TotalSize}";
+
+                    RespData = new VirtualStream(RespData, rangeStart, rangeLength);
+                    transferStart = rangeStart;
+                    responseLength = rangeLength;
 
                 }
                 else
+                {
+                    Context.Response.ContentLength = TaskInfo.TotalSize;
                     RespData = new VirtualStream(RespData, 0, TaskInfo.TotalSize);
+                }
 
                 ((VirtualStream)RespData).ForceAmount = true;
 
-                Context.Request.Keepalive = true;
+                RespData = new BufferedStream(RespData, TransferTuning.HttpServerBufferSize);
+                var transferStarted = DateTime.Now;
+                long responseSent = 0;
+                object progressLock = new object();
+
+                if (responseLength > 0)
+                {
+                    ProgressReporter?.Invoke(new TransferProgressInfo(
+                        Context.Request.Url.Full,
+                        transferStart,
+                        TaskInfo.TotalSize,
+                        0,
+                        responseLength,
+                        transferStarted,
+                        DateTime.Now,
+                        false));
+
+                    RespData = new TransferProgressStream(RespData, read =>
+                    {
+                        TransferProgressInfo ProgressInfo;
+                        lock (progressLock)
+                        {
+                            responseSent += read;
+                            ProgressInfo = new TransferProgressInfo(
+                                Context.Request.Url.Full,
+                                transferStart + responseSent,
+                                TaskInfo.TotalSize,
+                                responseSent,
+                                responseLength,
+                                transferStarted,
+                                DateTime.Now,
+                                false);
+                        }
+
+                        ProgressReporter?.Invoke(ProgressInfo);
+                    });
+                }
+
                 await Context.Response.SendAsync(Context.Response.ContentLength ?? TaskInfo.TotalSize, RespData);
+
+                if (responseLength > 0)
+                {
+                    ProgressReporter?.Invoke(new TransferProgressInfo(
+                        Context.Request.Url.Full,
+                        transferStart + responseLength,
+                        TaskInfo.TotalSize,
+                        responseLength,
+                        responseLength,
+                        transferStarted,
+                        DateTime.Now,
+                        true));
+                }
             }
             finally
             {
@@ -168,6 +244,34 @@ namespace DirectPackageInstaller.Host
                 if (FromPS4)
                     Instances[InstanceID]--;
             }
+        }
+
+        private static long GetRangeStart(HttpRange? Range, long TotalLength)
+        {
+            if (!Range.HasValue)
+                return 0;
+
+            if (Range.Value.Begin < 0)
+                return 0;
+
+            if (Range.Value.Begin > TotalLength)
+                return TotalLength;
+
+            return Range.Value.Begin;
+        }
+
+        private static long GetRangeLength(HttpRange? Range, long TotalLength)
+        {
+            long Start = GetRangeStart(Range, TotalLength);
+            long End = Range?.End ?? TotalLength - 1;
+
+            if (End >= TotalLength)
+                End = TotalLength - 1;
+
+            if (End < Start)
+                return 0;
+
+            return End - Start + 1;
         }
     }
 }

--- a/DirectPackageInstaller/DirectPackageInstaller/Host/HttpRange.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Host/HttpRange.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-//using WatsonWebserver;
+using System;
 
 namespace DirectPackageInstaller.Host
 {
@@ -7,23 +6,98 @@ namespace DirectPackageInstaller.Host
     {
         public HttpRange(string Header)
         {
-            var RangeStr = Header.Split('=').Last();
-            var BeginStr = RangeStr.Split('-').First();
-            var EndStr = RangeStr.Split('-').Last();
+            Begin = 0;
+            End = null;
+            IsSuffixRange = false;
+            SuffixLength = null;
+            IsValid = false;
 
-            if (string.IsNullOrWhiteSpace(EndStr) || EndStr == "*")
-                EndStr = null;
+            if (string.IsNullOrWhiteSpace(Header))
+                return;
 
-            Begin = long.Parse(BeginStr);
+            var EqualIndex = Header.IndexOf('=');
+            if (EqualIndex >= 0)
+            {
+                var Unit = Header.Substring(0, EqualIndex).Trim();
+                if (!Unit.Equals("bytes", StringComparison.OrdinalIgnoreCase))
+                    return;
+            }
 
-            if (EndStr != null)
-                End = long.Parse(EndStr);
-            else
-                End = null;
+            var RangeStr = EqualIndex >= 0 ? Header.Substring(EqualIndex + 1).Trim() : Header.Trim();
+            var CommaIndex = RangeStr.IndexOf(',');
+            if (CommaIndex >= 0)
+                RangeStr = RangeStr.Substring(0, CommaIndex).Trim();
+
+            var DashIndex = RangeStr.IndexOf('-');
+            if (DashIndex < 0)
+                return;
+
+            var BeginStr = RangeStr.Substring(0, DashIndex).Trim();
+            var EndStr = RangeStr.Substring(DashIndex + 1).Trim();
+
+            if (string.IsNullOrWhiteSpace(BeginStr))
+            {
+                if (long.TryParse(EndStr, out var ParsedSuffixLength) && ParsedSuffixLength > 0)
+                {
+                    IsSuffixRange = true;
+                    SuffixLength = ParsedSuffixLength;
+                    IsValid = true;
+                }
+                return;
+            }
+
+            if (!long.TryParse(BeginStr, out var ParsedBegin) || ParsedBegin < 0)
+                return;
+
+            Begin = ParsedBegin;
+
+            if (!string.IsNullOrWhiteSpace(EndStr) && EndStr != "*")
+            {
+                if (!long.TryParse(EndStr, out var ParsedEnd) || ParsedEnd < Begin)
+                    return;
+
+                End = ParsedEnd;
+            }
+
+            IsValid = true;
         }
 
         public long Begin;
         public long? End;
-        public long? Length => (End - Begin) + 1;
+        public bool IsValid;
+        public bool IsSuffixRange;
+        public long? SuffixLength;
+        public long? Length => IsSuffixRange ? SuffixLength : (End - Begin) + 1;
+
+        public long GetStart(long TotalLength)
+        {
+            if (!IsValid || TotalLength <= 0)
+                return 0;
+
+            if (IsSuffixRange)
+                return Math.Max(0, TotalLength - (SuffixLength ?? 0));
+
+            if (Begin > TotalLength)
+                return TotalLength;
+
+            return Begin;
+        }
+
+        public long GetLength(long TotalLength)
+        {
+            if (!IsValid || TotalLength <= 0)
+                return 0;
+
+            var Start = GetStart(TotalLength);
+            var EndPosition = IsSuffixRange ? TotalLength - 1 : End ?? TotalLength - 1;
+
+            if (EndPosition >= TotalLength)
+                EndPosition = TotalLength - 1;
+
+            if (EndPosition < Start)
+                return 0;
+
+            return EndPosition - Start + 1;
+        }
     }
 }

--- a/DirectPackageInstaller/DirectPackageInstaller/Host/PS4Server.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Host/PS4Server.cs
@@ -539,27 +539,15 @@ namespace DirectPackageInstaller.Host
             if (!Range.HasValue)
                 return 0;
 
-            if (Range.Value.Begin < 0)
-                return 0;
-
-            if (Range.Value.Begin > TotalLength)
-                return TotalLength;
-
-            return Range.Value.Begin;
+            return Range.Value.GetStart(TotalLength);
         }
 
         private static long GetRangeLength(HttpRange? Range, long TotalLength)
         {
-            long Start = GetRangeStart(Range, TotalLength);
-            long End = Range?.End ?? TotalLength - 1;
+            if (!Range.HasValue)
+                return TotalLength;
 
-            if (End >= TotalLength)
-                End = TotalLength - 1;
-
-            if (End < Start)
-                return 0;
-
-            return End - Start + 1;
+            return Range.Value.GetLength(TotalLength);
         }
         
         public string RegisterJSON(string URL, string PCIP, PKGHelper.PKGInfo Info, bool AutoSplit)

--- a/DirectPackageInstaller/DirectPackageInstaller/Host/PS4Server.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Host/PS4Server.cs
@@ -31,22 +31,28 @@ namespace DirectPackageInstaller.Host
         static TextWriter? LOGWRITER = null;
         public int Connections { get; private set; } = 0;
 
+        public static event Action<TransferProgressInfo>? GlobalTransferProgressChanged;
+        public event Action<TransferProgressInfo>? TransferProgressChanged;
+        public TransferProgressInfo? LastTransferProgress { get; private set; }
+
         public string LastRequestMode = null;
         public Webserver Server { get; private set; }
 
         public DecompressService Decompress = new DecompressService();
 
         public string IP { get => Server.Settings.Hostname; }
+        public int Port { get => Server.Settings.Port; }
         public PS4Server(string IP, int Port = 9898)
         {
             Server = new Webserver(new WebserverSettings(IP, Port)
             {
                 IO = new WebserverSettings.IOSettings()
                 {
-                    ReadTimeoutMs = 1000 * 60 * 5,
-                    StreamBufferSize = 1024 * 1024 * 2
+                    ReadTimeoutMs = TransferTuning.HttpServerReadTimeoutMs,
+                    StreamBufferSize = TransferTuning.HttpServerBufferSize
                 }
             });
+            Decompress.ProgressReporter = ReportTransferProgress;
 
 #if DEBUG
             if (LOGWRITER == null)
@@ -92,6 +98,13 @@ namespace DirectPackageInstaller.Host
             }
             catch { }
             LOG("Server Stopped");
+        }
+
+        private void ReportTransferProgress(TransferProgressInfo Info)
+        {
+            LastTransferProgress = Info;
+            TransferProgressChanged?.Invoke(Info);
+            GlobalTransferProgressChanged?.Invoke(Info);
         }
 
         private static int ConnectionID = 0;
@@ -186,7 +199,13 @@ namespace DirectPackageInstaller.Host
             Context.Response.StatusCode = Partial ? 206 : 200;
             Context.Response.StatusDescription = Partial ? "Partial Content" : "OK";
 
-            Stream Origin = System.IO.File.Open(Path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            Stream Origin = new FileStream(
+                Path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read,
+                TransferTuning.DiskBufferSize,
+                TransferTuning.LocalPackageFileOptions);
 
             try
             {
@@ -281,7 +300,7 @@ namespace DirectPackageInstaller.Host
             Context.Response.StatusDescription = Partial ? "Partial Content" : "OK";
 
             FileHostStream HttpStream;
-            HttpStream = new FileHostStream(Url, 1024 * 8);
+            HttpStream = new FileHostStream(Url);
 
             try
             {
@@ -344,7 +363,13 @@ namespace DirectPackageInstaller.Host
                         else if (SubQuery.AllKeys.Contains("b64"))
                             File = Encoding.UTF8.GetString(Convert.FromBase64String(SubQuery["b64"]));
 
-                        Source = System.IO.File.Open(File, FileMode.Open, FileAccess.Read, FileShare.Read);
+                        Source = new FileStream(
+                            File,
+                            FileMode.Open,
+                            FileAccess.Read,
+                            FileShare.Read,
+                            TransferTuning.DiskBufferSize,
+                            TransferTuning.LocalPackageFileOptions);
                     }
                 }
             }
@@ -402,11 +427,13 @@ namespace DirectPackageInstaller.Host
 
             try
             {
-                Context.Response.ContentLength = Origin.Length;
+                long totalLength = Origin.Length;
+                Context.Response.ContentLength = totalLength;
 
                 Context.Response.Headers["Connection"] = "Keep-Alive";
-                Context.Response.Headers["Accept-Ranges"] = "none";
+                Context.Response.Headers["Accept-Ranges"] = "bytes";
                 Context.Response.Headers["Content-Type"] = ContentType ?? "application/octet-stream";
+                Context.Request.Keepalive = true;
 
                 if (ContentType == null) {
                     if (Origin is FileHostStream)
@@ -418,19 +445,85 @@ namespace DirectPackageInstaller.Host
                 
                 if (Partial)
                 {
-                    Context.Response.ContentLength = Range?.Length ?? Origin.Length - Range?.Begin ?? Origin.Length;
-                    Context.Response.Headers["Content-Range"] = $"bytes {Range?.Begin ?? 0}-{Range?.End ?? Origin.Length}/{Origin.Length}";
+                    long rangeStart = GetRangeStart(Range, totalLength);
+                    long rangeLength = GetRangeLength(Range, totalLength);
+                    long rangeEnd = rangeStart + rangeLength - 1;
 
-                    Origin = new VirtualStream(Origin, Range?.Begin ?? 0, Context.Response.ContentLength.Value);
+                    if (rangeLength == 0)
+                    {
+                        Context.Response.StatusCode = 416;
+                        Context.Response.StatusDescription = "Range Not Satisfiable";
+                        Context.Response.Headers["Content-Range"] = $"bytes */{totalLength}";
+                        Context.Response.Send(true);
+                        return;
+                    }
+
+                    Context.Response.ContentLength = rangeLength;
+                    Context.Response.Headers["Content-Range"] = $"bytes {rangeStart}-{rangeEnd}/{totalLength}";
+
+                    Origin = new VirtualStream(Origin, rangeStart, rangeLength);
                 }
 
                 LOG("Response Context: {0}", Context.Request.Url.Full);
                 LOG("Content Length: {0}", Context.Response.ContentLength);
 
-                Origin = new BufferedStream(Origin);
+                var transferStart = Partial ? ((VirtualStream?)Origin)?.FilePos ?? 0 : 0;
+                var responseLength = Context.Response.ContentLength.Value;
+                var trackProgress = ContentType == null && responseLength > 0;
+                var transferStarted = DateTime.Now;
+                long responseSent = 0;
+                object progressLock = new object();
+
+                Origin = new BufferedStream(Origin, TransferTuning.HttpServerBufferSize);
+
+                if (trackProgress)
+                {
+                    ReportTransferProgress(new TransferProgressInfo(
+                        Context.Request.Url.Full,
+                        transferStart,
+                        totalLength,
+                        0,
+                        responseLength,
+                        transferStarted,
+                        DateTime.Now,
+                        false));
+
+                    Origin = new TransferProgressStream(Origin, read =>
+                    {
+                        TransferProgressInfo ProgressInfo;
+                        lock (progressLock)
+                        {
+                            responseSent += read;
+                            ProgressInfo = new TransferProgressInfo(
+                                Context.Request.Url.Full,
+                                transferStart + responseSent,
+                                totalLength,
+                                responseSent,
+                                responseLength,
+                                transferStarted,
+                                DateTime.Now,
+                                false);
+                        }
+
+                        ReportTransferProgress(ProgressInfo);
+                    });
+                }
 
                 var Token = new CancellationTokenSource();
                 await Context.Response.SendAsync(Context.Response.ContentLength.Value, Origin, Token.Token);
+
+                if (trackProgress)
+                {
+                    ReportTransferProgress(new TransferProgressInfo(
+                        Context.Request.Url.Full,
+                        transferStart + responseLength,
+                        totalLength,
+                        responseLength,
+                        responseLength,
+                        transferStarted,
+                        DateTime.Now,
+                        true));
+                }
             }
             finally
             {
@@ -439,6 +532,34 @@ namespace DirectPackageInstaller.Host
                 Origin?.Dispose();
                 GC.Collect();
             }
+        }
+
+        private static long GetRangeStart(HttpRange? Range, long TotalLength)
+        {
+            if (!Range.HasValue)
+                return 0;
+
+            if (Range.Value.Begin < 0)
+                return 0;
+
+            if (Range.Value.Begin > TotalLength)
+                return TotalLength;
+
+            return Range.Value.Begin;
+        }
+
+        private static long GetRangeLength(HttpRange? Range, long TotalLength)
+        {
+            long Start = GetRangeStart(Range, TotalLength);
+            long End = Range?.End ?? TotalLength - 1;
+
+            if (End >= TotalLength)
+                End = TotalLength - 1;
+
+            if (End < Start)
+                return 0;
+
+            return End - Start + 1;
         }
         
         public string RegisterJSON(string URL, string PCIP, PKGHelper.PKGInfo Info, bool AutoSplit)

--- a/DirectPackageInstaller/DirectPackageInstaller/Host/PayloadService.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Host/PayloadService.cs
@@ -170,6 +170,7 @@ namespace DirectPackageInstaller.Host
                 PayloadSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
                 PayloadSocket.ReceiveTimeout = 3000;
                 PayloadSocket.SendTimeout = 3000;
+                PayloadSocket.NoDelay = true;
 
                 CancellationTokenSource CToken = new CancellationTokenSource();
                 CToken.CancelAfter(3000);
@@ -214,6 +215,7 @@ namespace DirectPackageInstaller.Host
                     if (ServiceSocket == null)
                     {
                         ServiceSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                        ServiceSocket.NoDelay = true;
 
                         if (App.IsAndroid)
                             ServiceSocket.Bind(new IPEndPoint(IPAddress.Parse(PCIP), App.Config.PayloadPort ?? 0));
@@ -265,12 +267,14 @@ namespace DirectPackageInstaller.Host
                     {
                         var ClientSocket = await AcceptConnectionInBackground(CToken.Token);
                         if (ClientSocket == null) throw new NullReferenceException();
+                        ClientSocket.NoDelay = true;
                         Queue.Enqueue(ClientSocket);
                     }
                     else
                     {
                         var ClientSocket = await ServiceSocket.AcceptAsync(CToken.Token);
                         if (ClientSocket == null) throw new NullReferenceException();
+                        ClientSocket.NoDelay = true;
                         Queue.Enqueue(ClientSocket);
                     }
                 }

--- a/DirectPackageInstaller/DirectPackageInstaller/Host/TransferProgressInfo.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Host/TransferProgressInfo.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace DirectPackageInstaller.Host
+{
+    public sealed class TransferProgressInfo
+    {
+        public TransferProgressInfo(
+            string requestPath,
+            long bytesSent,
+            long totalBytes,
+            long responseBytesSent,
+            long responseBytesTotal,
+            DateTime startedAt,
+            DateTime updatedAt,
+            bool completed)
+        {
+            RequestPath = requestPath;
+            BytesSent = Math.Max(0, Math.Min(bytesSent, totalBytes));
+            TotalBytes = Math.Max(0, totalBytes);
+            ResponseBytesSent = Math.Max(0, Math.Min(responseBytesSent, responseBytesTotal));
+            ResponseBytesTotal = Math.Max(0, responseBytesTotal);
+            StartedAt = startedAt;
+            UpdatedAt = updatedAt;
+            Completed = completed;
+        }
+
+        public string RequestPath { get; }
+        public long BytesSent { get; }
+        public long TotalBytes { get; }
+        public long ResponseBytesSent { get; }
+        public long ResponseBytesTotal { get; }
+        public DateTime StartedAt { get; }
+        public DateTime UpdatedAt { get; }
+        public bool Completed { get; }
+
+        public double Percent => TotalBytes <= 0 ? 0 : (double)BytesSent / TotalBytes;
+
+        public double BytesPerSecond
+        {
+            get
+            {
+                var seconds = (UpdatedAt - StartedAt).TotalSeconds;
+                return seconds <= 0 ? 0 : ResponseBytesSent / seconds;
+            }
+        }
+
+        public static string FormatBytes(double bytes)
+        {
+            string[] units = { "B", "KB", "MB", "GB", "TB" };
+            var value = bytes;
+            var unit = 0;
+
+            while (value >= 1024 && unit < units.Length - 1)
+            {
+                value /= 1024;
+                unit++;
+            }
+
+            return $"{value:0.##} {units[unit]}";
+        }
+    }
+}

--- a/DirectPackageInstaller/DirectPackageInstaller/IO/FileHostStream.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/IO/FileHostStream.cs
@@ -12,7 +12,7 @@ namespace DirectPackageInstaller.IO
         public bool DirectLink { get; private set; } = true;
         public bool SingleConnection => Host?.Limited ?? false;
 
-        public FileHostStream(string Url, int cacheLen = 8192) : base(Url, cacheLen)
+        public FileHostStream(string Url, int cacheLen = TransferTuning.NetworkCacheSize) : base(Url, cacheLen)
         {
             App.WebClient.Proxy = null;
             

--- a/DirectPackageInstaller/DirectPackageInstaller/IO/NetworkStream.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/IO/NetworkStream.cs
@@ -38,7 +38,7 @@ namespace DirectPackageInstaller.IO
         public int Timeout { get; set; }
         public bool KeepAlive { get; set; } = false;
 
-        private const int CacheLen = 1024 * 8;
+        private const int CacheLen = TransferTuning.NetworkCacheSize;
 
         // Cache for short requests.
         private byte[] cache;
@@ -282,7 +282,7 @@ namespace DirectPackageInstaller.IO
                 ResponseStream?.Dispose();
                 ResponseStream = null;
 
-                if (Tries < 3)
+                if (Tries < TransferTuning.NetworkRetryCount)
                 {
                     RefreshUrl?.Invoke();
                     return NetRead(buffer, ref offset, ref count, Tries + 1);
@@ -359,7 +359,7 @@ namespace DirectPackageInstaller.IO
                         ReadResponseInfo(resp);
 
                     ResponseStream = resp.GetResponseStream();
-                    ResponseStream = new BufferedStream(ResponseStream);
+                    ResponseStream = new BufferedStream(ResponseStream, TransferTuning.NetworkBufferSize);
                 }
 
                 int nread = 0;
@@ -392,9 +392,9 @@ namespace DirectPackageInstaller.IO
                 ResponseStream?.Dispose();
                 ResponseStream = null;
 
-                if (Tries < 3)
+                if (Tries < TransferTuning.NetworkRetryCount)
                 {
-                    Thread.Sleep(Tries * 500);
+                    Thread.Sleep(Math.Min((Tries + 1) * 750, 5000));
 
                     RefreshUrl?.Invoke();
                     return NetRead(buffer, ref offset, ref count, Tries + 1);
@@ -410,8 +410,9 @@ namespace DirectPackageInstaller.IO
                 ResponseStream?.Dispose();
                 ResponseStream = null;
 
-                if (Tries < 3)
+                if (Tries < TransferTuning.NetworkRetryCount)
                 {
+                    Thread.Sleep(Math.Min((Tries + 1) * 750, 5000));
                     RefreshUrl?.Invoke();
                     return NetRead(buffer, ref offset, ref count, Tries + 1);
                 }
@@ -552,7 +553,8 @@ namespace DirectPackageInstaller.IO
             {
                 HttpWebRequest request = CreateNewRequest();
                 request.Method = NoHead ? "GET" : "HEAD";
-                request.Timeout = 15000;
+                request.Timeout = TransferTuning.UpstreamConnectTimeoutMs;
+                request.ReadWriteTimeout = TransferTuning.UpstreamReadWriteTimeoutMs;
 
                 request.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(SllBypass);
 
@@ -594,8 +596,14 @@ namespace DirectPackageInstaller.IO
             request.UserAgent = FileHostBase.UserAgent;
             request.ConnectionGroupName = Guid.NewGuid().ToString();
             request.KeepAlive = false;
+            request.Timeout = Timeout > 0 ? Timeout : TransferTuning.UpstreamConnectTimeoutMs;
+            request.ReadWriteTimeout = Timeout > 0 ? Timeout : TransferTuning.UpstreamReadWriteTimeoutMs;
+            request.AllowReadStreamBuffering = false;
             request.CookieContainer = Cookies;
             request.Proxy = Proxy;
+            request.ServicePoint.ConnectionLimit = Math.Max(request.ServicePoint.ConnectionLimit, 8);
+            request.ServicePoint.UseNagleAlgorithm = false;
+            request.ServicePoint.Expect100Continue = false;
             return request;
         }
 

--- a/DirectPackageInstaller/DirectPackageInstaller/IO/ReadSeekableStream.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/IO/ReadSeekableStream.cs
@@ -21,11 +21,12 @@ namespace DirectPackageInstaller
                 throw new Exception("Provided stream " + Input + " is not readable");
 
             InputStream = Input;
+            this.TempFile = TempFile;
             
             if (File.Exists(this.TempFile))
                 File.Delete(this.TempFile);
 
-            Buffer = new FileStream(this.TempFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.RandomAccess);
+            Buffer = new FileStream(this.TempFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite, TransferTuning.DiskBufferSize, TransferTuning.TempFileOptions);
         }
         public ReadSeekableStream(Stream Input)
         {
@@ -34,7 +35,7 @@ namespace DirectPackageInstaller
 
             InputStream = Input;
 
-            Buffer = new FileStream(TempFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.RandomAccess);
+            Buffer = new FileStream(TempFile, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite, TransferTuning.DiskBufferSize, TransferTuning.TempFileOptions);
         }
 
         public override bool CanRead { get { return true; } }
@@ -55,7 +56,7 @@ namespace DirectPackageInstaller
                     else
                     {
                         int sReaded;
-                        byte[] buff = new byte[1024 * 8];
+                        byte[] buff = new byte[TransferTuning.NetworkBufferSize];
                         do
                         {
                             sReaded = InputStream.Read(buff, 0, (int)(MustSkip > buff.Length ? buff.Length : MustSkip));
@@ -106,7 +107,7 @@ namespace DirectPackageInstaller
 
         long Copy(Stream From, Stream To, long Length) {
 
-            byte[] Buffer = new byte[1024 * 100];
+            byte[] Buffer = new byte[TransferTuning.NetworkBufferSize];
             long TotalReaded = 0;
             int Readed;
             do

--- a/DirectPackageInstaller/DirectPackageInstaller/IO/SegmentedStream.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/IO/SegmentedStream.cs
@@ -87,8 +87,8 @@ namespace DirectPackageInstaller.IO
                 if (File.Exists(TempFile))
                     File.Delete(TempFile);
                 
-                Buffer           = new FileStream(TempFile, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, BufferSize, FileOptions.RandomAccess | FileOptions.WriteThrough);
-                OpenBuffer = () => new FileStream(TempFile, FileMode.Open,      FileAccess.ReadWrite, FileShare.ReadWrite, BufferSize, FileOptions.RandomAccess | FileOptions.WriteThrough);
+                Buffer           = new FileStream(TempFile, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, BufferSize, TransferTuning.TempFileOptions);
+                OpenBuffer = () => new FileStream(TempFile, FileMode.Open,      FileAccess.ReadWrite, FileShare.ReadWrite, BufferSize, TransferTuning.TempFileOptions);
 
                 ReaderStream = OpenBuffer();
             }
@@ -116,7 +116,7 @@ namespace DirectPackageInstaller.IO
 
             lock (SegmentProgress)
             {
-                Segments.Add(new VirtualStream(new BufferedStream(First), 0, First.Length)
+                Segments.Add(new VirtualStream(new BufferedStream(First, BufferSize), 0, First.Length)
                 {
                     ForceAmount = true
                 });
@@ -177,7 +177,7 @@ namespace DirectPackageInstaller.IO
 
                         lock (SegmentProgress)
                         {
-                            Segments.Add(new VirtualStream(new BufferedStream(OpenSegment()), NewSegOffset, NewReaming)
+                            Segments.Add(new VirtualStream(new BufferedStream(OpenSegment(), BufferSize), NewSegOffset, NewReaming)
                             {
                                 ForceAmount = true
                             });

--- a/DirectPackageInstaller/DirectPackageInstaller/IO/TransferProgressStream.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/IO/TransferProgressStream.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DirectPackageInstaller.IO
+{
+    internal sealed class TransferProgressStream : Stream
+    {
+        private readonly Stream BaseStream;
+        private readonly Action<int> Progress;
+
+        public TransferProgressStream(Stream baseStream, Action<int> progress)
+        {
+            BaseStream = baseStream ?? throw new ArgumentNullException(nameof(baseStream));
+            Progress = progress ?? throw new ArgumentNullException(nameof(progress));
+        }
+
+        public override bool CanRead => BaseStream.CanRead;
+        public override bool CanSeek => BaseStream.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => BaseStream.Length;
+
+        public override long Position
+        {
+            get => BaseStream.Position;
+            set => BaseStream.Position = value;
+        }
+
+        public override void Flush() => BaseStream.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = BaseStream.Read(buffer, offset, count);
+            if (read > 0)
+                Progress(read);
+            return read;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var read = await BaseStream.ReadAsync(buffer, offset, count, cancellationToken);
+            if (read > 0)
+                Progress(read);
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await BaseStream.ReadAsync(buffer, cancellationToken);
+            if (read > 0)
+                Progress(read);
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => BaseStream.Seek(offset, origin);
+        public override void SetLength(long value) => BaseStream.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                BaseStream.Dispose();
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/DirectPackageInstaller/DirectPackageInstaller/Others/Settings.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Others/Settings.cs
@@ -31,6 +31,7 @@ namespace DirectPackageInstaller
         public bool EnableCNL;
 
         public bool ShowError;
+        public bool ShowTransferProgress;
 
         public bool AutoSplitPKG;
     }

--- a/DirectPackageInstaller/DirectPackageInstaller/Others/TransferTuning.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Others/TransferTuning.cs
@@ -1,0 +1,19 @@
+using System.IO;
+
+namespace DirectPackageInstaller
+{
+    internal static class TransferTuning
+    {
+        public const int HttpServerReadTimeoutMs = 1000 * 60 * 10;
+        public const int HttpServerBufferSize = 1024 * 1024 * 2;
+        public const int NetworkCacheSize = 1024 * 1024;
+        public const int NetworkBufferSize = 1024 * 1024;
+        public const int DiskBufferSize = 1024 * 1024;
+        public const int NetworkRetryCount = 5;
+        public const int UpstreamConnectTimeoutMs = 1000 * 30;
+        public const int UpstreamReadWriteTimeoutMs = 1000 * 60 * 5;
+
+        public const FileOptions TempFileOptions = FileOptions.RandomAccess;
+        public const FileOptions LocalPackageFileOptions = FileOptions.SequentialScan;
+    }
+}

--- a/DirectPackageInstaller/DirectPackageInstaller/SelfUpdate.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/SelfUpdate.cs
@@ -20,9 +20,12 @@ namespace DirectPackageInstaller
             {
                 try
                 {
+                    if (!string.IsNullOrWhiteSpace(Environment.ProcessPath) && File.Exists(Environment.ProcessPath))
+                        return Environment.ProcessPath;
+
                     var MainAssembly = System.Reflection.Assembly.GetEntryAssembly()?.Location;
 
-                    if (MainAssembly == null)
+                    if (string.IsNullOrWhiteSpace(MainAssembly))
                         return null;
 
                     if (File.Exists(Path.ChangeExtension(MainAssembly, "exe")))
@@ -250,9 +253,15 @@ namespace DirectPackageInstaller
 
             if (Directory.Exists(TempUpdateDir))
                 Directory.Delete(TempUpdateDir, true);
-                
-            if (File.Exists(Path.Combine(Path.GetDirectoryName(MainExecutable), "DirectPackageInstaller.exe")))
-                Delete(Path.Combine(Path.GetDirectoryName(MainExecutable), "DirectPackageInstaller.exe"));
+
+            var ExecutableDir = Path.GetDirectoryName(MainExecutable);
+            if (string.IsNullOrWhiteSpace(ExecutableDir))
+                return false;
+
+            var OldExecutable = Path.Combine(ExecutableDir, "DirectPackageInstaller.exe");
+            if (File.Exists(OldExecutable))
+                Delete(OldExecutable);
+
             return false;
         }
 

--- a/DirectPackageInstaller/DirectPackageInstaller/Tasks/Downloader.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Tasks/Downloader.cs
@@ -27,7 +27,7 @@ namespace DirectPackageInstaller.Tasks
 
             string TempFile = TempHelper.GetTempFile(URL + "DownTask");
 
-            var NewTask = new DownloaderTask(URL, TempFile, () => File.Open(TempFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
+            var NewTask = new DownloaderTask(URL, TempFile, () => new FileStream(TempFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, TransferTuning.DiskBufferSize, TransferTuning.TempFileOptions));
             NewTask.Running = true;
 
             BackgroundWorker Worker = new BackgroundWorker();
@@ -59,14 +59,14 @@ namespace DirectPackageInstaller.Tasks
             var This = (DownloaderTask)((object[])e.Argument)[0];
             var Stream = (Stream)((object[])e.Argument)[1] ?? new FileHostStream(This.Url);
 
-            This.OpenRead = () => File.Open(This.TempFile, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            This.OpenRead = () => new FileStream(This.TempFile, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite, TransferTuning.DiskBufferSize, TransferTuning.TempFileOptions);
 
             try
             {
-                using (Stream Output = File.Open(This.TempFile, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite))
-                using (Stream Input = new BufferedStream(Stream))
+                using (Stream Output = new FileStream(This.TempFile, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite, TransferTuning.DiskBufferSize, TransferTuning.TempFileOptions))
+                using (Stream Input = new BufferedStream(Stream, TransferTuning.NetworkBufferSize))
                 {
-                    byte[] Buffer = new byte[1024 * 1024 * 5];
+                    byte[] Buffer = new byte[TransferTuning.HttpServerBufferSize];
 
                     int Readed;
                     do

--- a/DirectPackageInstaller/DirectPackageInstaller/ViewModels/MainViewModel.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/ViewModels/MainViewModel.cs
@@ -75,6 +75,13 @@ namespace DirectPackageInstaller.ViewModels
             get => _SegmentedMode;
             set => this.RaiseAndSetIfChanged(ref _SegmentedMode, value);
         }
+
+        private bool _ShowTransferProgress = true;
+        public bool ShowTransferProgress
+        {
+            get => _ShowTransferProgress;
+            set => this.RaiseAndSetIfChanged(ref _ShowTransferProgress, value);
+        }
         
         private bool _useAllDebrid = false;
         public bool UseAllDebrid 

--- a/DirectPackageInstaller/DirectPackageInstaller/Views/MainView.axaml
+++ b/DirectPackageInstaller/DirectPackageInstaller/Views/MainView.axaml
@@ -34,6 +34,11 @@
                         <CheckBox BorderThickness="0" IsChecked="{Binding SegmentedMode, Mode=TwoWay}"/>
                     </MenuItem.Icon>
                 </MenuItem>
+                <MenuItem Header="_Transfer Progress" Name="btnTransferProgress" >
+                    <MenuItem.Icon>
+                        <CheckBox BorderThickness="0" IsChecked="{Binding ShowTransferProgress, Mode=TwoWay}"/>
+                    </MenuItem.Icon>
+                </MenuItem>
                 <MenuItem Header="_CNL Support" Name="btnCNLService" >
                     <MenuItem.Icon>
                         <CheckBox BorderThickness="0" IsChecked="{Binding CNLService, Mode=TwoWay}"/>

--- a/DirectPackageInstaller/DirectPackageInstaller/Views/MainView.axaml.cs
+++ b/DirectPackageInstaller/DirectPackageInstaller/Views/MainView.axaml.cs
@@ -56,6 +56,8 @@ namespace DirectPackageInstaller.Views
 
         private DecompressorHelperStream[]? CurrentDecompressorVolumes = null;
 
+        private DateTime LastTransferProgressUpdate = DateTime.MinValue;
+
         public MainViewModel? Model => (MainViewModel?)DataContext;
         
         public MainView()
@@ -81,6 +83,7 @@ namespace DirectPackageInstaller.Views
             btnRealDebirdEnabled = this.Find<MenuItem>("btnRealDebirdEnabled");
             btnDebirdLinkEnabled = this.Find<MenuItem>("btnDebirdLinkEnabled");
             btnSegmentedDownload = this.Find<MenuItem>("btnSegmentedDownload");
+            btnTransferProgress = this.Find<MenuItem>("btnTransferProgress");
             btnCNLService = this.Find<MenuItem>("btnCNLService");
             btnDHCPService = this.Find<MenuItem>("btnDHCPService");
             btnExit = this.Find<MenuItem>("btnExit");
@@ -93,6 +96,7 @@ namespace DirectPackageInstaller.Views
             btnRealDebirdEnabled.Click += BtnRealDebirdEnabledOnClick;
             btnDebirdLinkEnabled.Click += BtnDebirdLinkEnabledOnClick;
             btnSegmentedDownload.Click += BtnSegmentedDownloadOnClick;
+            btnTransferProgress.Click += BtnTransferProgressOnClick;
             btnCNLService.Click += BtnCNLServiceOnClick;
             btnDHCPService.Click += BtnDHCPServiceOnClick;
 
@@ -104,6 +108,7 @@ namespace DirectPackageInstaller.Views
             btnExit.IsVisible = App.IsAndroid;
             
             CNL.OnLinksReceived = OnLinksReceived;
+            PS4Server.GlobalTransferProgressChanged += ServerOnTransferProgressChanged;
             
             PreviewGrid.PropertyChanged += PreviewGridOnPropertyChanged;
 
@@ -145,6 +150,8 @@ namespace DirectPackageInstaller.Views
                 App.Config.DebridLinkApiKey = IniReader.GetValue("DebridLinkApiKey");
                 App.Config.EnableCNL = IniReader.GetBooleanValue("EnableCNL");
                 App.Config.ShowError = IniReader.GetBooleanValue("ShowError");
+                var ShowTransferProgress = IniReader.GetValue("ShowTransferProgress");
+                App.Config.ShowTransferProgress = string.IsNullOrWhiteSpace(ShowTransferProgress) || IniReader.GetBooleanValue("ShowTransferProgress");
                 App.Config.SkipUpdateCheck = IniReader.GetBooleanValue("SkipUpdateCheck");
                 App.Config.AutoSplitPKG = IniReader.GetBooleanValue("AutoSplitPKG");
 
@@ -173,6 +180,7 @@ namespace DirectPackageInstaller.Views
                     UseAllDebrid = false,
                     EnableCNL = true,
                     ShowError = false,
+                    ShowTransferProgress = true,
                     SkipUpdateCheck = false,
                     EnableDHCP = false,
                     AllDebridApiKey = null,
@@ -195,6 +203,7 @@ namespace DirectPackageInstaller.Views
             Model.DHCPService = App.Config.EnableDHCP;
             Model.CNLService = App.Config.EnableCNL;
             Model.ProxyMode = App.Config.ProxyDownload;
+            Model.ShowTransferProgress = App.Config.ShowTransferProgress;
             Model.UseAllDebrid = App.Config.UseAllDebrid;
             Model.UseDebridLink = App.Config.UseDebridLink;
             Model.SegmentedMode = App.Config.SegmentedDownload;
@@ -810,6 +819,9 @@ namespace DirectPackageInstaller.Views
                 case "SegmentedMode":
                     App.Config.SegmentedDownload = Model.SegmentedMode;
                     break;
+                case "ShowTransferProgress":
+                    App.Config.ShowTransferProgress = Model.ShowTransferProgress;
+                    break;
                 case "PS4IP":
                     App.Config.PSIP = Model.PS4IP;
                     break;
@@ -881,6 +893,14 @@ namespace DirectPackageInstaller.Views
                 return;
             
             Model.SegmentedMode = !Model.SegmentedMode;
+        }
+
+        private void BtnTransferProgressOnClick(object? sender, RoutedEventArgs e)
+        {
+            if (Model == null)
+                return;
+
+            Model.ShowTransferProgress = !Model.ShowTransferProgress;
         }
 
         private void BtnProxyDownloadOnClick(object? sender, RoutedEventArgs e)
@@ -1269,6 +1289,37 @@ namespace DirectPackageInstaller.Views
             {
                 App.Callback(() => this.Status.Text = Status);
             }
+        }
+
+        private void ServerOnTransferProgressChanged(TransferProgressInfo Info)
+        {
+            if (!App.Config.ShowTransferProgress)
+                return;
+
+            var Now = DateTime.Now;
+            if (!Info.Completed && (Now - LastTransferProgressUpdate).TotalMilliseconds < 500)
+                return;
+
+            LastTransferProgressUpdate = Now;
+            var ProgressStatus = FormatTransferProgress(Info);
+
+            App.Callback(() =>
+            {
+                if (App.Config.ShowTransferProgress)
+                    Status.Text = ProgressStatus;
+            });
+        }
+
+        private static string FormatTransferProgress(TransferProgressInfo Info)
+        {
+            var Sent = TransferProgressInfo.FormatBytes(Info.BytesSent);
+            var Total = TransferProgressInfo.FormatBytes(Info.TotalBytes);
+
+            if (Info.Completed)
+                return $"Sent {Sent} / {Total}";
+
+            var Speed = TransferProgressInfo.FormatBytes(Info.BytesPerSecond);
+            return $"Sending {Sent} / {Total} ({Info.Percent:P1}) - {Speed}/s";
         }
         
         private async void RestartServer_OnClick(object? sender, RoutedEventArgs? e)


### PR DESCRIPTION
## What changed

This PR focuses on making DirectPackageInstaller behave better when the console is pulling data over a local network, especially on Wi-Fi where stalls and retries are more noticeable.

- Adds shared transfer tuning for HTTP streaming, upstream reads, disk buffering, retry count, and temp/local file options.
- Uses larger buffers for proxied downloads, local PKG reads, segmented streams, decompression output, and cached downloads.
- Keeps local HTTP responses alive and advertises byte-range support while tightening range response handling.
- Hardens HTTP `Range` parsing so malformed headers, suffix ranges, and multi-range headers do not crash the transfer server.
- Disables Nagle on payload sockets so small control messages are not delayed.
- Adds optional transfer progress reporting:
  - GUI: `Options -> Transfer Progress`
  - CLI: `-Progress`
- Reports sent bytes, total bytes, percent, and transfer speed while the console reads from DirectPackageInstaller.
- Fixes a single-file publish startup crash in the updater by resolving the executable from `Environment.ProcessPath` when `Assembly.Location` is empty.

## Why

For large PKG installs, the PS4/PS5 is effectively reading from DirectPackageInstaller as a local server. Small buffers, short retry behavior, and limited visibility make Wi-Fi transfers feel unreliable: users cannot tell whether the console is still reading, how fast data is moving, or whether the transfer is stuck.

The changes here keep the existing install flow intact but make the sender side more tolerant and easier to observe.

## Validation

I followed the repository's documented build path as closely as this local Windows environment allows.

- Passed: `dotnet build DirectPackageInstaller\DirectPackageInstaller.Desktop\DirectPackageInstaller.Desktop.csproj -c Release`
- Passed after the range-header hardening: `dotnet build DirectPackageInstaller\DirectPackageInstaller.Desktop\DirectPackageInstaller.Desktop.csproj -c Release --no-restore`
- Passed: `dotnet publish DirectPackageInstaller\DirectPackageInstaller.Desktop\DirectPackageInstaller.Desktop.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -o C:\tmp\DirectPackageInstaller-win-x64`
- Passed: `git diff --check`
- Attempted: `cmd /c Build.cmd`

`Build.cmd` started the documented Windows build flow, but this local machine could not complete packaging because PowerShell could not load `Microsoft.PowerShell.Archive` for `Compress-Archive` / `Expand-Archive`. A full solution build is also blocked locally by missing Android SDK configuration. The repository's GitHub Actions workflow provides the correct Android SDK/NDK and macOS signing environments, so those platform builds should run in CI for this PR.

The build still has existing nullable/obsolete API warnings unrelated to this change; no new compile errors were introduced in the desktop build.
